### PR TITLE
feat: add landing page and basic routing

### DIFF
--- a/frontend/src/App.svelte
+++ b/frontend/src/App.svelte
@@ -1,17 +1,8 @@
 <script>
-  import { onMount } from 'svelte';
-
-  let players = [];
-
-  onMount(async () => {
-    const res = await fetch("http://localhost:8080/players");
-    players = await res.json();
-  });
 </script>
 
-<h2>Players</h2>
-<ul>
-  {#each players as player}
-    <li>{player.name}</li>
-  {/each}
-</ul>
+<main>
+  <h1>Welcome to the app</h1>
+  <p>This is the landing page.</p>
+  <a href="/players">View Players</a>
+</main>

--- a/frontend/src/Players.svelte
+++ b/frontend/src/Players.svelte
@@ -1,0 +1,23 @@
+<script lang="ts">
+  import { onMount } from 'svelte';
+
+  interface Player {
+    name: string;
+  }
+
+  let players: Player[] = [];
+
+  onMount(async () => {
+    const res = await fetch("http://localhost:8080/players");
+    players = await res.json();
+  });
+</script>
+
+<h2>Players</h2>
+<ul>
+  {#each players as player}
+    <li>{player.name}</li>
+  {/each}
+</ul>
+
+<a href="/">Back to Home</a>

--- a/frontend/src/main.ts
+++ b/frontend/src/main.ts
@@ -1,9 +1,17 @@
-import { mount } from 'svelte'
-import './app.css'
-import App from './App.svelte'
+import { mount } from 'svelte';
+import './app.css';
+import App from './App.svelte';
+import Players from './Players.svelte';
 
-const app = mount(App, {
+const routes: Record<string, any> = {
+  '/': App,
+  '/players': Players,
+};
+
+const component = routes[window.location.pathname] ?? App;
+
+const app = mount(component, {
   target: document.getElementById('app')!,
-})
+});
 
-export default app
+export default app;


### PR DESCRIPTION
## Summary
- provide a simple landing page at the default route
- move player listing into its own page and add basic client-side routing

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run check`


------
https://chatgpt.com/codex/tasks/task_e_689019ac468c8329ad3b4949eb209f4a